### PR TITLE
all sources: ensure valid callsigns are ASCII, allow /s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Issue where trustee or image from QRZ could be empty (#22).
 - Improve handling of malformed dates in received data (#24).
+- Issue where callsigns containing '/' were marked invalid (#20).
 
 
 ## [1.0.1] - 2021-09-27

--- a/callsignlookuptools/callook/callookasync.py
+++ b/callsignlookuptools/callook/callookasync.py
@@ -11,6 +11,7 @@ from typing import Optional
 import aiohttp
 
 from ..common import mixins, dataclasses, exceptions
+from ..common.functions import is_callsign
 from .callook import CallookClientAbc
 
 
@@ -35,7 +36,7 @@ class CallookAsyncClient(mixins.AsyncMixin, CallookClientAbc):
         return obj
 
     async def search(self, callsign: str) -> dataclasses.CallsignData:  # type: ignore[override]
-        if not callsign.isalnum():
+        if not is_callsign(callsign):
             raise exceptions.CallsignLookupError("Invalid Callsign")
 
         return self._process_search(

--- a/callsignlookuptools/callook/callooksync.py
+++ b/callsignlookuptools/callook/callooksync.py
@@ -11,6 +11,7 @@ from typing import Optional
 import requests
 
 from ..common import mixins, dataclasses, exceptions
+from ..common.functions import is_callsign
 from .callook import CallookClientAbc
 
 
@@ -27,7 +28,7 @@ class CallookSyncClient(mixins.SyncMixin, CallookClientAbc):
         super().__init__()
 
     def search(self, callsign: str) -> dataclasses.CallsignData:
-        if not callsign.isalnum():
+        if not is_callsign(callsign):
             raise exceptions.CallsignLookupError("Invalid Callsign")
 
         return self._process_search(

--- a/callsignlookuptools/common/functions.py
+++ b/callsignlookuptools/common/functions.py
@@ -43,3 +43,8 @@ def xml2dict(xml: Union[bytes, etree._Element], to_lower: bool = True) -> Dict:
         else:
             result[key] = value
     return result
+
+
+def is_callsign(callsign: str) -> bool:
+    """Check if a callsign is valid"""
+    return callsign.isascii() and callsign.replace("/", "").isalnum()

--- a/callsignlookuptools/hamqth/hamqthasync.py
+++ b/callsignlookuptools/hamqth/hamqthasync.py
@@ -13,6 +13,7 @@ import aiohttp
 
 from ..common import mixins, dataclasses, exceptions
 from ..common.constants import DEFAULT_USERAGENT
+from ..common.functions import is_callsign
 from .hamqth import HamQthClientAbc
 
 
@@ -49,7 +50,7 @@ class HamQthAsyncClient(mixins.AsyncXmlAuthMixin, mixins.AsyncMixin, HamQthClien
         return obj
 
     async def search(self, callsign: str) -> dataclasses.CallsignData:  # type: ignore[override]
-        if not callsign.isalnum():
+        if not is_callsign(callsign):
             raise exceptions.CallsignLookupError("Invalid Callsign")
         try:
             await self._check_session(

--- a/callsignlookuptools/hamqth/hamqthsync.py
+++ b/callsignlookuptools/hamqth/hamqthsync.py
@@ -13,6 +13,7 @@ import requests
 
 from ..common import mixins, dataclasses, exceptions
 from ..common.constants import DEFAULT_USERAGENT
+from ..common.functions import is_callsign
 from .hamqth import HamQthClientAbc
 
 
@@ -35,7 +36,7 @@ class HamQthSyncClient(mixins.SyncXmlAuthMixin, mixins.SyncMixin, HamQthClientAb
         super().__init__(username, password, session_key=session_key, useragent=useragent)
 
     def search(self, callsign: str) -> dataclasses.CallsignData:
-        if not callsign.isalnum():
+        if not is_callsign(callsign):
             raise exceptions.CallsignLookupError("Invalid Callsign")
         try:
             self._check_session(

--- a/callsignlookuptools/qrz/qrzasync.py
+++ b/callsignlookuptools/qrz/qrzasync.py
@@ -13,6 +13,7 @@ import aiohttp
 
 from ..common import mixins, dataclasses, exceptions
 from ..common.constants import DEFAULT_USERAGENT
+from ..common.functions import is_callsign
 from .qrz import QrzClientAbc
 
 
@@ -49,7 +50,7 @@ class QrzAsyncClient(mixins.AsyncXmlAuthMixin, mixins.AsyncMixin, QrzClientAbc):
         return obj
 
     async def search(self, callsign: str) -> dataclasses.CallsignData:  # type: ignore[override]
-        if not callsign.isalnum():
+        if not is_callsign(callsign):
             raise exceptions.CallsignLookupError("Invalid Callsign")
         try:
             await self._check_session(

--- a/callsignlookuptools/qrz/qrzsync.py
+++ b/callsignlookuptools/qrz/qrzsync.py
@@ -13,6 +13,7 @@ import requests
 
 from ..common import mixins, dataclasses, exceptions
 from ..common.constants import DEFAULT_USERAGENT
+from ..common.functions import is_callsign
 from .qrz import QrzClientAbc
 
 
@@ -35,7 +36,7 @@ class QrzSyncClient(mixins.SyncXmlAuthMixin, mixins.SyncMixin, QrzClientAbc):
         super().__init__(username, password, session_key=session_key, useragent=useragent)
 
     def search(self, callsign: str) -> dataclasses.CallsignData:
-        if not callsign.isalnum():
+        if not is_callsign(callsign):
             raise exceptions.CallsignLookupError("Invalid Callsign")
         try:
             self._check_session(

--- a/callsignlookuptools/qrzcq/qrzcqasync.py
+++ b/callsignlookuptools/qrzcq/qrzcqasync.py
@@ -13,6 +13,7 @@ import aiohttp
 
 from ..common import mixins, dataclasses, exceptions
 from ..common.constants import DEFAULT_USERAGENT
+from ..common.functions import is_callsign
 from .qrzcq import QrzCqClientAbc
 
 
@@ -49,7 +50,7 @@ class QrzCqAsyncClient(mixins.AsyncXmlAuthMixin, mixins.AsyncMixin, QrzCqClientA
         return obj
 
     async def search(self, callsign: str) -> dataclasses.CallsignData:  # type: ignore[override]
-        if not callsign.isalnum():
+        if not is_callsign(callsign):
             raise exceptions.CallsignLookupError("Invalid Callsign")
         try:
             await self._check_session(

--- a/callsignlookuptools/qrzcq/qrzcqsync.py
+++ b/callsignlookuptools/qrzcq/qrzcqsync.py
@@ -13,6 +13,7 @@ import requests
 
 from ..common import mixins, dataclasses, exceptions
 from ..common.constants import DEFAULT_USERAGENT
+from ..common.functions import is_callsign
 from .qrzcq import QrzCqClientAbc
 
 
@@ -35,7 +36,7 @@ class QrzCqSyncClient(mixins.SyncXmlAuthMixin, mixins.SyncMixin, QrzCqClientAbc)
         super().__init__(username, password, session_key=session_key, useragent=useragent)
 
     def search(self, callsign: str) -> dataclasses.CallsignData:
-        if not callsign.isalnum():
+        if not is_callsign(callsign):
             raise exceptions.CallsignLookupError("Invalid Callsign")
         try:
             self._check_session(


### PR DESCRIPTION
the ascii check is to ensure python doesn't count non-A-Z alphabetic characters or non arabic numerals as alphanumeric (yay unicode!)

fixes #20
