### PR TITLE
docs: remove references to click-help-colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ pip install callsignlookuptools[all]
 $ pip install callsignlookuptools[cli]
 ```
 
-**Note:** If `requests`, `aiohttp`, or `typer[all]` and `click-help-colors` are installed another way, you will also have access to the sync, async, or command-line interface, respectively.
+**Note:** If `requests`, `aiohttp`, or `typer[all]` are installed another way, you will also have access to the sync, async, or command-line interface, respectively.
 
 ## Usage and Documentation
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,7 +2,7 @@
 CLI Usage
 =========
 
-.. NOTE:: To use the CLI, install with the extra ``cli`` (e.g. ``pip install callsignlookuptools[cli]``) or otherwise install the library ``typer[all]`` and ``click-help-colors``.
+.. NOTE:: To use the CLI, install with the extra ``cli`` (e.g. ``pip install callsignlookuptools[cli]``) or otherwise install the library ``typer[all]``.
 
 ``callsignlookuptools`` has a basic CLI interface, which can be run using:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ Installation
     # enable the CLI
     $ pip install callsignlookuptools[cli]
 
-.. NOTE:: If ``requests``, ``aiohttp``, or ``typer[all]`` and ``click-help-colors`` are installed another way, you will also have access to the sync, async, or command-line interface, respectively.
+.. NOTE:: If ``requests``, ``aiohttp``, or ``typer[all]`` are installed another way, you will also have access to the sync, async, or command-line interface, respectively.
 
 API Support
 ===========

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ requests
 aiohttp
 pydantic
 typer[all]
-click-help-colors


### PR DESCRIPTION
no longer used