### PR TITLE
Fixed multiword city names causing a ValueError

### DIFF
--- a/callsignlookuptools/callook/callook.py
+++ b/callsignlookuptools/callook/callook.py
@@ -145,7 +145,8 @@ class CallookClientAbc(abcs.LookupAbc, ABC):
         state = None
         zip = None
         if model_data.address.line2:
-            city, state, zip = model_data.address.line2.replace(",", "").split(" ")
+            zip, state, *city_parts = model_data.address.line2.replace(",", "").split(" ")[::-1]
+            city = " ".join(city_parts[::-1])
         calldata.address = dataclasses.Address(
             attn=model_data.address.attn,
             line1=model_data.address.line1,


### PR DESCRIPTION
### Description

Replaced the (elegant) replace-and-split line2 line with a less-elegant set of lines that additionally handle multiword city names.

Fixes #38 

### Type of change

- Bug fix

### How has this been tested?

```python
from callsignlookuptools import CallookSyncClient, CallsignLookupError

callook_lookup = CallookSyncClient()

for callsign in ["W3UNX","WB0BK","KJ7ZHG","NA6JD","W9BLN","AK6FK","K1FIE", "W1AW"]:
  lookup_result = callook_lookup.search(callsign)
  print(lookup_result.address.city)
```

Test cases chosen because (except for `W1AW`, which is just there for a one-word control) these were some of the callsigns I was getting crashes on, when building a "send my giant pile of QSOs at once" tool for [my ham radio club's pro-vaccine event](https://nars.narwhal.be/polio/). Had I gotten off my butt and tried to send the QSL cards in a more timely fashion, I would have submitted this bugfix earlier, so my apologies for that.

### Checklist

- [x] Issue exists for PR
- [x] Code reviewed by the author
- [x] Code documented (comments or other documentation)
- [x] Changes tested
- [x] All tests pass (see [`DEVELOPING.md`][0], if it exists)
- [x] [`CHANGELOG.md`][1] updated if needed (I don't think this merits a CHANGELOG notice)
- [x] Informative commit messages
- [x] Descriptive PR title

[0]: /DEVELOPING.md
[1]: /CHANGELOG.md
